### PR TITLE
Merge actions into attributes and relationships

### DIFF
--- a/momaapi/lookup.py
+++ b/momaapi/lookup.py
@@ -130,8 +130,6 @@ class Lookup:
                         self.taxonomy["sact"],
                         self.taxonomy["actor"],
                         self.taxonomy["object"],
-                        self.taxonomy["ia"],
-                        self.taxonomy["ta"],
                         self.taxonomy["att"],
                         self.taxonomy["rel"],
                     )
@@ -143,8 +141,6 @@ class Lookup:
                             ann_hoi_raw,
                             self.taxonomy["actor"],
                             self.taxonomy["object"],
-                            self.taxonomy["ia"],
-                            self.taxonomy["ta"],
                             self.taxonomy["att"],
                             self.taxonomy["rel"],
                         )

--- a/momaapi/moma.py
+++ b/momaapi/moma.py
@@ -35,7 +35,8 @@ The following attributes are defined:
 
  
 Definitions:
- - kind: ['act', 'sact', 'hoi', 'actor', 'object', 'ia', 'ta', 'att', 'rel']
+ - kind: ['act', 'sact', 'hoi', 'actor', 'object', 'att', 'rel']
+   * Note: ['ia', 'ta'] are deprecated.
 """
 
 
@@ -53,8 +54,6 @@ class MOMA:
     * ``sact``: sub-activity
     * ``hoi``: higher-order interaction
     * ``entity``: entity
-    * ``ia``: intransitive action
-    * ``ta``: transitive action
     * ``att``: attribute
     * ``rel``: relationship
     * ``ann``: annotation
@@ -101,13 +100,13 @@ class MOMA:
 
     def get_cids(
         self,
-        kind: Literal["act", "sact", "actor", "object", "ia", "ta", "att", "rel"],
+        kind: Literal["act", "sact", "actor", "object", "att", "rel"],
         threshold: int,
         split: Literal["train", "val", "test", "either", "all", "combined"],
     ) -> list:
         """
         :param kind: the kind of annotations needed to be retrieved
-        :type kind: Literal['act', 'sact', 'actor', 'object', 'ia', 'ta', 'att', 'rel']
+        :type kind: Literal['act', 'sact', 'actor', 'object', 'att', 'rel']
         :param threshold: exclude classes with fewer than this number of total instances
         :type threshold: int
         :param split: the split to be used for the retrieval. Here, ``train`` refers to
@@ -187,17 +186,8 @@ class MOMA:
         else:
             raise ValueError
 
-    def get_cnames(
-        self,
-        cids_act: list = None,
-        cids_sact: list = None,
-        cids_actor: list = None,
-        cids_object: list = None,
-        cids_ia: list = None,
-        cids_ta: list = None,
-        cids_att: list = None,
-        cids_rel: list = None,
-    ) -> list:
+    def get_cnames(self, cids_act: list = None, cids_sact: list = None, cids_actor: list = None,
+                   cids_object: list = None, cids_att: list = None, cids_rel: list = None) -> list:
         """
         Returns the associated class names given the class IDs.
 
@@ -209,10 +199,6 @@ class MOMA:
         :type cids_actor: Optional[List[int]]
         :param cids_object: a list of class IDs of objects
         :type cids_object: Optional[List[int]]
-        :param cids_ia: a list of class IDs of intransitive actions
-        :type cids_ia: Optional[List[int]]
-        :param cids_ta: a list of class IDs of transitive actions
-        :type cids_ta: Optional[List[int]]
         :param cids_att: a list of class IDs of attributes
         :type cids_att: Optional[List[int]]
         :param cids_rel: a list of class IDs of relationships
@@ -225,12 +211,10 @@ class MOMA:
             cids_sact,
             cids_actor,
             cids_object,
-            cids_ia,
-            cids_ta,
             cids_att,
             cids_rel,
         ]
-        kinds = ["act", "sact", "actor", "object", "ia", "ta", "att", "rel"]
+        kinds = ["act", "sact", "actor", "object", "att", "rel"]
 
         indices = [i for i, x in enumerate(args) if x is not None]
         assert len(indices) == 1
@@ -325,19 +309,9 @@ class MOMA:
         ids_act_intersection = sorted(set.intersection(*map(set, ids_act_intersection)))
         return ids_act_intersection
 
-    def get_ids_sact(
-        self,
-        split: str = None,
-        cnames_sact: list = None,
-        ids_act: list = None,
-        ids_hoi: list = None,
-        cnames_actor: list = None,
-        cnames_object: list = None,
-        cnames_ia: list = None,
-        cnames_ta: list = None,
-        cnames_att: list = None,
-        cnames_rel: list = None,
-    ) -> list:
+    def get_ids_sact(self, split: str = None, cnames_sact: list = None, ids_act: list = None, ids_hoi: list = None,
+                     cnames_actor: list = None, cnames_object: list = None, cnames_att: list = None,
+                     cnames_rel: list = None) -> list:
         """
         Get the unique sub-activity instance IDs that satisfy certain conditions
         dataset split
@@ -354,10 +328,6 @@ class MOMA:
         :type cnames_actor: list
         :param cnames_object: get sub-activity IDs [ids_sact] for given object class names [cnames_object]
         :type cnames_object: list
-        :param cnames_ia: get sub-activity IDs [ids_sact] for given intransitive action class names [cnames_ia]
-        :type cnames_ia: list
-        :param cnames_ta: get sub-activity IDs [ids_sact] for given transitive action class names [cnames_ta]
-        :type cnames_ta: list
         :param cnames_att: get sub-activity IDs [ids_sact] for given attribute class names [cnames_att]
         :type cnames_att: list
         :param cnames_rel: get sub-activity IDs [ids_sact] for given relationship class names [cnames_rel]
@@ -374,8 +344,6 @@ class MOMA:
                 ids_hoi,
                 cnames_actor,
                 cnames_object,
-                cnames_ia,
-                cnames_ta,
                 cnames_att,
                 cnames_rel,
             ]
@@ -387,9 +355,7 @@ class MOMA:
         # split
         if split is not None:
             assert split in self.lookup.retrieve("splits")
-            ids_sact = self.get_ids_sact(
-                ids_act=self.lookup.retrieve("ids_act", f"{self.paradigm}_{split}")
-            )
+            ids_sact = self.get_ids_sact(ids_act=self.lookup.retrieve("ids_act", f"{self.paradigm}_{split}"))
             ids_sact_intersection.append(ids_sact)
 
         # cnames_sact
@@ -415,14 +381,12 @@ class MOMA:
             ]
             ids_sact_intersection.append(ids_sact)
 
-        # cnames_actor, cnames_object, cnames_ia, cnames_ta, cnames_att, cnames_rel
+        # cnames_actor, cnames_object, cnames_att, cnames_rel
         if not all(
             x is None
             for x in [
                 cnames_actor,
                 cnames_object,
-                cnames_ia,
-                cnames_ta,
                 cnames_att,
                 cnames_rel,
             ]
@@ -430,8 +394,6 @@ class MOMA:
             kwargs = {
                 "cnames_actor": cnames_actor,
                 "cnames_object": cnames_object,
-                "cnames_ia": cnames_ia,
-                "cnames_ta": cnames_ta,
                 "cnames_att": cnames_att,
                 "cnames_rel": cnames_rel,
             }
@@ -446,18 +408,8 @@ class MOMA:
         )
         return ids_sact_intersection
 
-    def get_ids_hoi(
-        self,
-        split: str = None,
-        ids_act: list = None,
-        ids_sact: list = None,
-        cnames_actor: list = None,
-        cnames_object: list = None,
-        cnames_ia: list = None,
-        cnames_ta: list = None,
-        cnames_att: list = None,
-        cnames_rel: list = None,
-    ) -> list:
+    def get_ids_hoi(self, split: str = None, ids_act: list = None, ids_sact: list = None, cnames_actor: list = None,
+                    cnames_object: list = None, cnames_att: list = None, cnames_rel: list = None) -> list:
         """
         Get the unique higher-order interaction instance IDs that satisfy certain conditions
         dataset split
@@ -472,10 +424,6 @@ class MOMA:
         :type cnames_actor: list
         :param cnames_object: get higher-order interaction IDs [ids_hoi] for given object class names [cnames_object]
         :type cnames_object: list
-        :param cnames_ia: get higher-order interaction IDs [ids_hoi] for given intransitive action class names [cnames_ia]
-        :type cnames_ia: list
-        :param cnames_ta: get higher-order interaction IDs [ids_hoi] for given transitive action class names [cnames_ta]
-        :type cnames_ta: list
         :param cnames_att: get higher-order interaction IDs [ids_hoi] for given attribute class names [cnames_att]
         :type cnames_att: list
         :param cnames_rel: get higher-order interaction IDs [ids_hoi] for given relationship class names [cnames_rel]
@@ -489,8 +437,6 @@ class MOMA:
                 ids_sact,
                 cnames_actor,
                 cnames_object,
-                cnames_ia,
-                cnames_ta,
                 cnames_att,
                 cnames_rel,
             ]
@@ -502,9 +448,7 @@ class MOMA:
         # split
         if split is not None:
             assert split in self.lookup.retrieve("splits")
-            ids_hoi = self.get_ids_hoi(
-                ids_act=self.lookup.retrieve("ids_act", f"{self.paradigm}_{split}")
-            )
+            ids_hoi = self.get_ids_hoi(ids_act=self.lookup.retrieve("ids_act", f"{self.paradigm}_{split}"))
             ids_hoi_intersection.append(ids_hoi)
 
         # ids_act
@@ -524,12 +468,10 @@ class MOMA:
             )
             ids_hoi_intersection.append(ids_hoi)
 
-        # cnames_actor, cnames_object, cnames_ia, cnames_ta, cnames_att, cnames_rel
+        # cnames_actor, cnames_object, cnames_att, cnames_rel
         cnames_dict = {
             "actors": cnames_actor,
             "objects": cnames_object,
-            "ias": cnames_ia,
-            "tas": cnames_ta,
             "atts": cnames_att,
             "rels": cnames_rel,
         }

--- a/momaapi/statistics.py
+++ b/momaapi/statistics.py
@@ -197,14 +197,6 @@ class Statistics(dict):
             set([object.cid for ann_hoi in anns_hoi for object in ann_hoi.objects])
         )
 
-        num_ias = sum([len(ann_hoi.ias) for ann_hoi in anns_hoi])
-        num_classes_ia = len(
-            set([ia.cid for ann_hoi in anns_hoi for ia in ann_hoi.ias])
-        )
-        num_tas = sum([len(ann_hoi.tas) for ann_hoi in anns_hoi])
-        num_classes_ta = len(
-            set([ta.cid for ann_hoi in anns_hoi for ta in ann_hoi.tas])
-        )
         num_atts = sum([len(ann_hoi.atts) for ann_hoi in anns_hoi])
         num_classes_att = len(
             set([att.cid for ann_hoi in anns_hoi for att in ann_hoi.atts])
@@ -240,16 +232,12 @@ class Statistics(dict):
         (
             bincount_actor,
             bincount_object,
-            bincount_ia,
-            bincount_ta,
             bincount_att,
             bincount_rel,
-        ) = ([], [], [], [], [], [])
+        ) = ([], [], [], [])
         for ann_hoi in anns_hoi:
             bincount_actor += [actor.cid for actor in ann_hoi.actors]
             bincount_object += [object.cid for object in ann_hoi.objects]
-            bincount_ia += [ia.cid for ia in ann_hoi.ias]
-            bincount_ta += [ta.cid for ta in ann_hoi.tas]
             bincount_att += [att.cid for att in ann_hoi.atts]
             bincount_rel += [rel.cid for rel in ann_hoi.rels]
         bincount_actor = np.bincount(
@@ -257,12 +245,6 @@ class Statistics(dict):
         ).tolist()
         bincount_object = np.bincount(
             bincount_object, minlength=len(self._taxonomy["object"])
-        ).tolist()
-        bincount_ia = np.bincount(
-            bincount_ia, minlength=len(self._taxonomy["ia"])
-        ).tolist()
-        bincount_ta = np.bincount(
-            bincount_ta, minlength=len(self._taxonomy["ta"])
         ).tolist()
         bincount_att = np.bincount(
             bincount_att, minlength=len(self._taxonomy["att"])
@@ -304,16 +286,6 @@ class Statistics(dict):
                 "num_instances_video": num_objects_video,
                 "num_classes": num_classes_object,
                 "distribution": bincount_object,
-            },
-            "ia": {
-                "num_instances": num_ias,
-                "num_classes": num_classes_ia,
-                "distribution": bincount_ia,
-            },
-            "ta": {
-                "num_instances": num_tas,
-                "num_classes": num_classes_ta,
-                "distribution": bincount_ta,
             },
             "att": {
                 "num_instances": num_atts,

--- a/momaapi/taxonomy.py
+++ b/momaapi/taxonomy.py
@@ -33,23 +33,6 @@ class Taxonomy(dict):
         with open(osp.join(dir_moma, "anns/taxonomy/object.json"), "r") as f:
             taxonomy_object = json.load(f)
             taxonomy_object = sorted(itertools.chain(*taxonomy_object.values()))
-
-        # ia and ta may have been merged with attributes and relationships
-        try:
-            with open(
-                osp.join(dir_moma, "anns/taxonomy/intransitive_action.json"), "r"
-            ) as f:
-                taxonomy_ia = json.load(f)
-                taxonomy_ia = sorted(map(tuple, itertools.chain(*taxonomy_ia.values())))
-        except FileNotFoundError:
-            taxonomy_ia = None
-        try:
-            with open(osp.join(dir_moma, "anns/taxonomy/transitive_action.json"), "r") as f:
-                taxonomy_ta = json.load(f)
-                taxonomy_ta = sorted(map(tuple, itertools.chain(*taxonomy_ta.values())))
-        except FileNotFoundError:
-            taxonomy_ta = None
-
         with open(osp.join(dir_moma, "anns/taxonomy/attribute.json"), "r") as f:
             taxonomy_att = json.load(f)
             taxonomy_att = sorted(map(tuple, itertools.chain(*taxonomy_att.values())))
@@ -106,13 +89,6 @@ class Taxonomy(dict):
                 }
             ),
         }
-
-        # If ia is not None, combine it with att
-        if taxonomy_ia is not None:
-            taxonomy_att = taxonomy_ia + taxonomy_att
-        # If ta is not None, combine it with rel
-        if taxonomy_ta is not None:
-            taxonomy_rel = taxonomy_ta + taxonomy_rel
 
         taxonomy = {
             "actor": taxonomy_actor,

--- a/momaapi/taxonomy.py
+++ b/momaapi/taxonomy.py
@@ -33,14 +33,23 @@ class Taxonomy(dict):
         with open(osp.join(dir_moma, "anns/taxonomy/object.json"), "r") as f:
             taxonomy_object = json.load(f)
             taxonomy_object = sorted(itertools.chain(*taxonomy_object.values()))
-        with open(
-            osp.join(dir_moma, "anns/taxonomy/intransitive_action.json"), "r"
-        ) as f:
-            taxonomy_ia = json.load(f)
-            taxonomy_ia = sorted(map(tuple, itertools.chain(*taxonomy_ia.values())))
-        with open(osp.join(dir_moma, "anns/taxonomy/transitive_action.json"), "r") as f:
-            taxonomy_ta = json.load(f)
-            taxonomy_ta = sorted(map(tuple, itertools.chain(*taxonomy_ta.values())))
+
+        # ia and ta may have been merged with attributes and relationships
+        try:
+            with open(
+                osp.join(dir_moma, "anns/taxonomy/intransitive_action.json"), "r"
+            ) as f:
+                taxonomy_ia = json.load(f)
+                taxonomy_ia = sorted(map(tuple, itertools.chain(*taxonomy_ia.values())))
+        except FileNotFoundError:
+            taxonomy_ia = None
+        try:
+            with open(osp.join(dir_moma, "anns/taxonomy/transitive_action.json"), "r") as f:
+                taxonomy_ta = json.load(f)
+                taxonomy_ta = sorted(map(tuple, itertools.chain(*taxonomy_ta.values())))
+        except FileNotFoundError:
+            taxonomy_ta = None
+
         with open(osp.join(dir_moma, "anns/taxonomy/attribute.json"), "r") as f:
             taxonomy_att = json.load(f)
             taxonomy_att = sorted(map(tuple, itertools.chain(*taxonomy_att.values())))
@@ -98,11 +107,16 @@ class Taxonomy(dict):
             ),
         }
 
+        # If ia is not None, combine it with att
+        if taxonomy_ia is not None:
+            taxonomy_att = taxonomy_ia + taxonomy_att
+        # If ta is not None, combine it with rel
+        if taxonomy_ta is not None:
+            taxonomy_rel = taxonomy_ta + taxonomy_rel
+
         taxonomy = {
             "actor": taxonomy_actor,
             "object": taxonomy_object,
-            "ia": taxonomy_ia,
-            "ta": taxonomy_ta,
             "att": taxonomy_att,
             "rel": taxonomy_rel,
             "act": taxonomy_act,

--- a/momaapi/visualizers/ann.py
+++ b/momaapi/visualizers/ann.py
@@ -135,7 +135,7 @@ class AnnVisualizer:
                 color="salmon3",
                 shape="circle",
             )
-        for predicate in ann_hoi.tas + ann_hoi.rels:
+        for predicate in ann_hoi.rels:
             G.add_edge(
                 (predicate.id_src, predicate.id_trg),
                 label=predicate.cname,
@@ -144,7 +144,7 @@ class AnnVisualizer:
                 fontsize="10",
                 len=2,
             )
-        for predicate in ann_hoi.ias + ann_hoi.atts:
+        for predicate in ann_hoi.atts:
             G.add_edge(
                 (predicate.id_src, predicate.id_src),
                 label=predicate.cname,
@@ -240,11 +240,11 @@ class AnnVisualizer:
         info_edges = []
         for ann_hoi in anns_hoi:
             edge_to_labels = defaultdict(list)
-            for predicate in ann_hoi.tas + ann_hoi.rels:
+            for predicate in ann_hoi.rels:
                 edge_to_labels[(predicate.id_src, predicate.id_trg)].append(
                     predicate.cname
                 )
-            for predicate in ann_hoi.ias + ann_hoi.atts:
+            for predicate in ann_hoi.atts:
                 edge_to_labels[(predicate.id_src, predicate.id_src)].append(
                     predicate.cname
                 )
@@ -309,11 +309,11 @@ class AnnVisualizer:
 
             # draw edges
             edge_to_labels = defaultdict(list)
-            for predicate in ann_hoi.tas + ann_hoi.rels:
+            for predicate in ann_hoi.rels:
                 edge_to_labels[(predicate.id_src, predicate.id_trg)].append(
                     predicate.cname
                 )
-            for predicate in ann_hoi.ias + ann_hoi.atts:
+            for predicate in ann_hoi.atts:
                 edge_to_labels[(predicate.id_src, predicate.id_src)].append(
                     predicate.cname
                 )

--- a/scripts/visualize_stats.ipynb
+++ b/scripts/visualize_stats.ipynb
@@ -6,10 +6,7 @@
     "# Dataset Statistics Visualization"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -21,10 +18,7 @@
     "from momaapi import MOMA, StatVisualizer"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -33,10 +27,7 @@
     "Initialize MOMA API."
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -57,10 +48,7 @@
     "moma = MOMA(dir_moma)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -71,14 +59,10 @@
     "visualizer = StatVisualizer(moma)\n",
     "names = {\"act\": \"Activity\", \"sact\": \"Sub-activity\",\n",
     "         \"actor\": \"Actor\", \"object\": \"Object\",\n",
-    "         \"ia\": \"Intransitive action\", \"ta\": \"Transitive action\",\n",
     "         \"att\": \"Attribute\", \"rel\": \"Relationship\"}"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -87,10 +71,7 @@
     "## Overall Statistics"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -102,10 +83,7 @@
     "paths = visualizer.show(with_split=False)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -239,10 +217,7 @@
     "    display(Image(path))"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -251,10 +226,7 @@
     "## Statistics by Split"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%% md\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -266,10 +238,7 @@
     "paths = visualizer.show(with_split=True)"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -403,10 +372,7 @@
     "    display(Image(path))"
    ],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   },
   {
@@ -415,10 +381,7 @@
    "outputs": [],
    "source": [],
    "metadata": {
-    "collapsed": false,
-    "pycharm": {
-     "name": "#%%\n"
-    }
+    "collapsed": false
    }
   }
  ],


### PR DESCRIPTION
This PR merges intransitive actions into attributes and transitive actions into relationships.

- For backward compatibility: In the taxonomy loading process, the program searches for `transitive_action.json` and `intransitive_action.json`. If the files exist, they are loaded and merged into attributes and relationships taxonomy. This change is reflected in momaapi/taxonomy.py.
- For most other occurrences, the ia/ta variables are simply deleted. 

This version is tested on all .py and .ipynb scripts under `scripts` folder. All tests are passed. 